### PR TITLE
Fix: Ensure font visibility in light mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -257,6 +257,7 @@ html {
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background;
+    color: hsl(var(--foreground));
   }
 }


### PR DESCRIPTION
I updated src/app/globals.css to explicitly set the body text color to use the --foreground CSS variable. This ensures that the correct contrasting text color is applied in both light and dark modes, addressing an issue where fonts were not visible in light mode.